### PR TITLE
Fix hidden sequence view bug

### DIFF
--- a/src/scripts/HorizontalDynseqTrack.js
+++ b/src/scripts/HorizontalDynseqTrack.js
@@ -288,7 +288,7 @@ export default function HDT(HGC, ...args) {
         if (maxZoom === undefined) {
           maxZoom = this.tilesetInfo.resolutions.length;
         }
-        this.calculateZoomLevel();
+        this.zoomLevel = this.calculateZoomLevel();
         // At most 2048 characters on screen
         const shouldFetchFasta = maxZoom - this.zoomLevel < 2;
         this.dataFetcher.setFilter(_ => shouldFetchFasta, 1)


### PR DESCRIPTION
This change fixes the bug where the sequence doesn't show up unless you zoom out then back in again:

Example bug here: https://resgen.io/pete/dynseq-test/views/HrxUkPieSP-ZPfHRjXBdyg